### PR TITLE
VM MGMT - VMs not in the CORP0 bridge

### DIFF
--- a/Virtlyst/root/src/networks.html
+++ b/Virtlyst/root/src/networks.html
@@ -119,7 +119,7 @@
 
                         <div class="col-sm-6">
                             <input type="text" class="form-control" name="bridge_name" placeholder="br0"
-                                   pattern="[a-z0-9\-_:]+">
+                                   pattern="[A-Za-z0-9\-_:]+">
                         </div>
                     </div>
                     <div class="form-group bridge_name_form_group">


### PR DESCRIPTION
VM MGMT - VMs not in the CORP0 bridge
validation was preventing to create a bridge  name
